### PR TITLE
Fixing permissions for accepting TOS

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -14,4 +14,7 @@ commands:
     aliases: [sign]
     permission: CivMenu.*
     usage: /sign
- 
+permissions:
+    CivMenu.*:
+      description: Gives access to /sign and /help
+      default: true


### PR DESCRIPTION
I made this pull request against black's repo a few days ago, but he might have forgotten about it. Currently no non-op can accept the TOS on civtest, because permissions are set to op only per default.
