### PR TITLE
Fixes

### DIFF
--- a/src/vg/civcraft/mc/civmenu/CivMenu.java
+++ b/src/vg/civcraft/mc/civmenu/CivMenu.java
@@ -52,7 +52,7 @@ public class CivMenu extends ACivMod {
 		Menu menu = new Menu();
 
 		if (plugin == null) {
-			TextComponent title = new TextComponent("Civcraft Help Meu");
+			TextComponent title = new TextComponent("Civcraft Help Menu");
 			title.setColor(ChatColor.RED);
 			menu.setTitle(title);
 			menu.setSubTitle(new TextComponent(this.GetConfig().get("helpMenu.message").getString()));


### PR DESCRIPTION
This fixes Civcraft/CivMenu#5, Civcraft/CivMenu#6, Civcraft/CivMenu#8

I have tested all changes. 
- Spelling error corrected
- PlayerMoveEvent will not process a null location
- Respawning clears the old location, and the move event updates itself with the new location after respawn. This works after death, and also if the player is kicked while dead and respawns after a reconnect.
